### PR TITLE
Add HTTPS to the front-end route

### DIFF
--- a/openshift-template.yaml
+++ b/openshift-template.yaml
@@ -258,6 +258,9 @@ objects:
       host: ${FRONTEND_HOSTNAME}
       port:
         targetPort: web
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
       to:
         kind: Service
         name: f2-reviewrot-frontend


### PR DESCRIPTION
Since it seems like we aren't using any FQDNs not managed by UpShift for this app, so this should be all it takes to enable HTTPS.