### PR TITLE
Add https://pagure.io/fedora-ci/messages

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -35,6 +35,7 @@ git_services:
     - set-jira-paf
     - fedrepo_req
     - module_diff
+    - fedora-ci/messages
   - type: gitlab
     host: https://gitlab.cee.redhat.com
     token: ENV.GITLAB_TOKEN


### PR DESCRIPTION
This is a repo that houses an open-source version of a machine-readable spec
for the "F2.0 UMB CI message format".  It's not something we own, but it is
something we'll want to be aware of changes to.