### PR TITLE
Always re-run all build instructions

### DIFF
--- a/openshift-template.yaml
+++ b/openshift-template.yaml
@@ -34,6 +34,7 @@ objects:
           from:
             kind: ImageStreamTag
             name: nonroot-nginx:latest
+          noCache: true
       triggers:
         - github:
             secretReference:
@@ -67,6 +68,7 @@ objects:
           from:
             kind: ImageStreamTag
             name: centos:7
+          noCache: true
       triggers:
         - github:
             secretReference:


### PR DESCRIPTION
The Dockerfiles used are generic enough to pick up changes upstream
without modifications. This change makes sure that build layers are not
cached and reused during rebuilds.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>